### PR TITLE
feat: Simplify SEO titles by removing the "CROUStillant" prefix in mutiple sections

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -28,7 +28,7 @@
     "clickToSeeLess": "See less",
     "markerDescription": "View the menu of the restaurant <link>{name}</link>.",
     "seo": {
-      "title": "Restaurants - CROUStillant",
+      "title": "Restaurants",
       "description": "Discover the list of CROUS restaurants in France and overseas. Find the perfect restaurant for your next meal!",
       "keywords": "CROUS, restaurant, menu"
     }
@@ -41,11 +41,11 @@
     "noMealAvailable": "No meal available for this restaurant 😢",
     "noMealAvailableDescription": "The restaurant does not offer any meal. Please try again later.",
     "seo": {
-      "title": "Menu of {name} - CROUStillant",
+      "title": "Menu of {name}",
       "description": "Discover the details of {name}, located in {area}. Perfect for your next meal!",
       "keywords": "CROUS, restaurant, menu, {name}, {area}",
       "notFound": {
-        "title": "Restaurant not found - CROUStillant",
+        "title": "Restaurant not found",
         "description": "The restaurant you are looking for does not exist or has been moved."
       }
     },
@@ -189,7 +189,7 @@
       "button": "Join our Discord server"
     },
     "seo": {
-      "title": "About - CROUStillant",
+      "title": "About",
       "description": "Discover the CROUStillant project, its team and its operation. Learn more about the platform and its features.",
       "keywords": "CROUS, restaurant, menu, about"
     }
@@ -388,7 +388,7 @@
       "deleteDataSuccessDescription": "All your data has been successfully deleted."
     },
     "seo": {
-      "title": "Settings - CROUStillant",
+      "title": "Settings",
       "description": "Configure your settings on CROUStillant to personalize your experience.",
       "keywords": "CROUS, restaurant, menu, settings"
     }
@@ -428,7 +428,7 @@
       }
     },
     "seo": {
-      "title": "Statistics - CROUStillant",
+      "title": "Statistics",
       "description": "Discover the statistics of CROUStillant. Stay informed of the number of menus, compositions, categories, meals and dishes added per day.",
       "keywords": "CROUS, restaurant, menu, statistics"
     }
@@ -437,7 +437,7 @@
     "title": "Dishes",
     "description": "Discover the dishes offered by the restaurants CROUS of France and overseas.",
     "seo": {
-      "title": "Dishes - CROUStillant",
+      "title": "Dishes",
       "description": "Discover the dishes offered by the CROUS restaurants of France and overseas. Find the perfect dish for your next meal!",
       "keywords": "CROUS, restaurant, menu, dishes"
     },
@@ -544,7 +544,7 @@
       }
     },
     "seo": {
-      "title": "Legal notices - CROUStillant",
+      "title": "Legal notices",
       "description": "Find all the legal information about CROUStillant and its operation. Discover the terms of use, privacy policy and cookie policy.",
       "keywords": "CROUS, restaurant, menu, legal"
     }
@@ -559,7 +559,7 @@
     },
     "footer": "We love to hear from you, just not through forms. 🍴",
     "seo": {
-      "title": "Contact Us - CROUStillant",
+      "title": "Contact Us",
       "description": "Get in touch with the CROUStillant team to report a bug, suggest an improvement or just chat with us!",
       "keywords": "CROUS, restaurant, menu, contact"
     }
@@ -577,7 +577,7 @@
     "buildInProgress": "The build is in progress...",
     "buildInProgressDescription": "This page is currently being built. It may have some display issues.",
     "seo": {
-      "title": "Changelog - CROUStillant",
+      "title": "Changelog",
       "description": "Discover the latest changes and updates made to CROUStillant. Stay informed of the latest features and improvements.",
       "keywords": "CROUS, restaurant, menu, changelog"
     }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -28,7 +28,7 @@
     "clickToSeeLess": "Voir moins",
     "markerDescription": "Voir le menu du restaurant <link>{name}</link>.",
     "seo": {
-      "title": "Restaurants - CROUStillant",
+      "title": "Restaurants",
       "description": "Découvrez les restaurants CROUS de France et d'outre-mer. Trouvez le restaurant parfait pour votre prochain repas !",
       "keywords": "CROUS, restaurant, menu"
     }
@@ -41,11 +41,11 @@
     "noMealAvailable": "Aucun plat disponible pour ce restaurant 😢",
     "noMealAvailableDescription": "Le restaurant ne propose aucun plat. Veuillez réessayer plus tard.",
     "seo": {
-      "title": "Menu de {name} - CROUStillant",
+      "title": "Menu de {name}",
       "description": "Découvrez les détails de {name}, situé à {area}. Parfait pour votre prochain repas !",
       "keywords": "CROUS, restaurant, menu, {name}, {area}",
       "notFound": {
-        "title": "Restaurant introuvable - CROUStillant",
+        "title": "Restaurant introuvable",
         "description": "Le restaurant que vous cherchez n'existe pas ou a été déplacé."
       }
     },
@@ -189,7 +189,7 @@
       "button": "Notre serveur Discord"
     },
     "seo": {
-      "title": "À propos - CROUStillant",
+      "title": "À propos",
       "description": "Découvrez l'équipe de CROUStillant, le projet et les fonctionnalités du service. Nous sommes là pour vous aider !",
       "keywords": "CROUS, restaurant, menu, équipe, projet"
     }
@@ -389,7 +389,7 @@
       "deleteDataSuccessDescription": "Toutes les données ont été supprimées avec succès."
     },
     "seo": {
-      "title": "Paramètres - CROUStillant",
+      "title": "Paramètres",
       "description": "Personnalisez les paramètres de CROUStillant pour une expérience optimale.",
       "keywords": "CROUS, restaurant, menu, paramètres"
     }
@@ -429,7 +429,7 @@
       }
     },
     "seo": {
-      "title": "Statistiques - CROUStillant",
+      "title": "Statistiques",
       "description": "Découvrez les statistiques de CROUStillant. Nombre de menus, compositions, catégories, repas et plats ajoutés par jour.",
       "keywords": "CROUS, restaurant, menu, statistiques"
     }
@@ -438,7 +438,7 @@
     "title": "Plats",
     "description": "Découvrez les plats proposés par les restaurants CROUS de France et d'outre-mer.",
     "seo": {
-      "title": "Plats - CROUStillant",
+      "title": "Plats",
       "description": "Découvrez les plats proposés par les restaurants CROUS de France et d'outre-mer. Trouvez le plat parfait pour votre prochain repas !",
       "keywords": "CROUS, restaurant, menu, plat, plats"
     },
@@ -545,7 +545,7 @@
       }
     },
     "seo": {
-      "title": "Notice légale - CROUStillant",
+      "title": "Notice légale",
       "description": "Consultez les mentions légales, la politique de confidentialité, les cookies et les conditions d'utilisation de CROUStillant. Nous sommes là pour vous aider !",
       "keywords": "CROUS, restaurant, menu, mentions légales, politique de confidentialité"
     }
@@ -560,7 +560,7 @@
     },
     "footer": "Nous adorons avoir de vos nouvelles, mais pas via des formulaires. 🍴",
     "seo": {
-      "title": "Contact - CROUStillant",
+      "title": "Contact",
       "description": "Contactez l'équipe de CROUStillant pour toute question, suggestion ou problème. Nous sommes à votre service !",
       "keywords": "CROUS, restaurant, menu, contact"
     }
@@ -578,7 +578,7 @@
     "buildInProgress": "Construction en cours...",
     "buildInProgressDescription": "Cette page est en cours de construction. Elle peut présenter des problèmes d'affichage.",
     "seo": {
-      "title": "Mises à jour - CROUStillant",
+      "title": "Mises à jour",
       "description": "Découvrez les dernières mises à jour de CROUStillant et les fonctionnalités ajoutées. Restez informé des nouveautés !",
       "keywords": "CROUS, restaurant, menu, mises à jour"
     }


### PR DESCRIPTION
Fix "CROUStillant" duplicates in SEO title.