### PR TITLE
fix(filters): correct default sort comparator in sortRestaurants

### DIFF
--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -91,6 +91,6 @@ export const sortRestaurants = (
     }
 
     // if no sort is applied, sort by restaurant's area
-    return a.zone.localeCompare(b.nom, locale);
+    return a.zone.localeCompare(b.zone, locale);
   });
 };


### PR DESCRIPTION
## Changement
Correction du comparateur de tri par défaut dans `filters.ts`.

## Pourquoi
Le tri par défaut comparait `a.zone` avec `b.nom` au lieu de `a.zone` avec `b.zone`( comme précisé en commentaire), ce qui produisait un ordre de tri incorrect et incohérent pour les restaurants.

## Fichiers modifiés
- `src/lib/filters.ts`